### PR TITLE
Suppress octokit deprecation warning

### DIFF
--- a/src/github-notify.ts
+++ b/src/github-notify.ts
@@ -1,4 +1,4 @@
-const Octokit = require("@octokit/rest");
+import Octokit from "@octokit/rest";
 
 type Props = {
   owner: string;
@@ -17,11 +17,16 @@ export const notifyGithubPr = async ({
   artifactUrl,
   body
 }: Props) => {
+  const issue_number = Number(number)
+  if (Number.isNaN(issue_number)) {
+    console.error("Invalid Pull Request Id");
+    return;
+  }
   const octokit = new Octokit({ auth: `token ${token}` });
   return octokit.issues.createComment({
     owner,
     repo,
-    number,
+    issue_number,
     body: `${body}:\n${artifactUrl}`
   });
 };

--- a/src/github-notify.ts
+++ b/src/github-notify.ts
@@ -3,7 +3,7 @@ import Octokit from "@octokit/rest";
 type Props = {
   owner: string;
   repo: string;
-  number: string | number;
+  issue_number: number;
   token: string;
   artifactUrl: string;
   body: string;
@@ -12,16 +12,11 @@ type Props = {
 export const notifyGithubPr = async ({
   owner,
   repo,
-  number,
+  issue_number,
   token,
   artifactUrl,
   body
 }: Props) => {
-  const issue_number = Number(number)
-  if (Number.isNaN(issue_number)) {
-    console.error("Invalid Pull Request Id");
-    return;
-  }
   const octokit = new Octokit({ auth: `token ${token}` });
   return octokit.issues.createComment({
     owner,

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export const moxci = async (targetPath: string, options: Options) => {
 
   // Github
   if (GITHUB_TOKEN) {
-    const pullRequestId = CIRCLE_PULL_REQUEST.split("/").pop();
+    const pullRequestId = Number(CIRCLE_PULL_REQUEST.split("/").pop());
     if (!pullRequestId) {
       console.error("Invalid Pull Request Id");
       return;
@@ -64,7 +64,7 @@ export const moxci = async (targetPath: string, options: Options) => {
     notifyGithubPr({
       owner: CIRCLE_PROJECT_USERNAME,
       repo: CIRCLE_PROJECT_REPONAME,
-      number: pullRequestId,
+      issue_number: pullRequestId,
       token: GITHUB_TOKEN,
       artifactUrl,
       body: options.message


### PR DESCRIPTION
Hello Naturalclar :wave: 
I'm a big fan of moxci and noticed deprecation warning when used on CircleCI.
just below:

```
Deprecation: [@octokit/rest] "number" parameter is deprecated for ".issues.createComment()". Use "issue_number" instead
  …
  at Object.exports.notifyGithubPr (/home/circleci/some_repo/node_modules/moxci/lib/github-notify.js:42:12) {
  name: 'Deprecation'
}
```

The `number` parameter has been deprecated and seems to have been changed to an `issue_number`.
So I tried some fixes. Please review.